### PR TITLE
Add secret bank options in the backend (#1)

### DIFF
--- a/include/cruxpass.h
+++ b/include/cruxpass.h
@@ -50,11 +50,20 @@ typedef enum {
   C_RET_OKK  // C_RET_OKK: Custom OK 2
 } ERROR_T;
 
-char *random_secret(int secret_len);
+typedef struct {
+  bool uppercase;     // Uppercase alphabets
+  bool lowercase;     // Lowercase alphabets
+  bool numbers;
+  bool symbols;
+  bool exclude_ambiguous;
+} secret_bank_options_t;
+
+char *random_secret(int secret_len, secret_bank_options_t *bank_options);
 char *setpath(char *);
 int create_new_master_secret(sqlite3 *db, unsigned char *key);
 int export_secrets(sqlite3 *db, const char *export_file);
 int import_secrets(sqlite3 *db, char *import_file);
 sqlite3 *initcrux(void);
+char *init_secret_bank(const secret_bank_options_t *options);
 
 #endif  // !CRUXPASS_H

--- a/src/main.c
+++ b/src/main.c
@@ -44,8 +44,15 @@ int main(int argc, const char **argv) {
   }
 
   if (password_len != 0) {
+    secret_bank_options_t bank_options;
+    memset(&bank_options, 0, sizeof(secret_bank_options_t));
+    bank_options.uppercase = true;
+    bank_options.lowercase = true;
+    bank_options.numbers = true;
+    bank_options.symbols = true;
+    bank_options.exclude_ambiguous = true;
     char *secret = NULL;
-    if ((secret = random_secret(password_len)) == NULL) {
+    if ((secret = random_secret(password_len, &bank_options)) == NULL) {
       return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
### Pull Request Summary
I have added following options to secret bank:

- [x] Uppercase alphabets
- [x] Lowercase alphabets
- [x] Numbers
- [x] Symbols
- [x] Exclude ambiguous characters

Summary of updated files (you can view details during merging):
- `cruxpass.h`: Added struct for options, and updated function prototypes
- `cruxpass.c`: Added function `init_secret_bank()` and updated function `random_secret()`
- `main.c`: Only updated section where function `random_secret()` is called to generate a random password

### Examples of using new secret bank options
**Example 1: Only use alphabets for password:**
```
secret_bank_options_t bank_options;
memset(&bank_options, 0, sizeof(secret_bank_options_t));
bank_options.uppercase = true;
bank_options.lowercase = true;
char *secret = random_secret(password_len, &bank_options);
```

**Example 2: Use alphabets and numbers but exclude any ambiguous characters:**
```
secret_bank_options_t bank_options;
memset(&bank_options, 0, sizeof(secret_bank_options_t));
bank_options.uppercase = true;
bank_options.lowercase = true;
bank_options.numbers = true;
bank_options.exclude_ambiguous = true;
char *secret = random_secret(password_len, &bank_options);
```

**Example 3: Use all available secret banks but exclude any ambiguous characters (currently default in `main()`):**
```
secret_bank_options_t bank_options;
memset(&bank_options, 0, sizeof(secret_bank_options_t));
bank_options.uppercase = true;
bank_options.lowercase = true;
bank_options.numbers = true;
bank_options.symbols = true;
bank_options.exclude_ambiguous = true;
char *secret = random_secret(password_len, &bank_options);
```

### What to do next?
This PR adds secret bank options to the backend of the app. However, as of now, these options are not available to user. TUI needs to be updated, so that user can supply options through command-line arguments. Then in `main()` or relevant function will apply these options (as in above examples) before calling `random_secret()` function.

### Future updates
If desired then in future, more characters can be removed from unambiguous characters arrays while retaining the options for user to select all characters (all secret banks) including ambiguous characters.